### PR TITLE
Add build openmpi

### DIFF
--- a/build_install_openmpi.sh
+++ b/build_install_openmpi.sh
@@ -106,7 +106,7 @@ echo "===> Making temporary build dir"
 # up development testing of downstream Spack actions
 export OMPI_TMP_BUILD_DIR=${PW_SW_ROOT}/tmp/openmpi
 #rm -rf $OMPI_TMP_BUILD_DIR
-mkdir -p ${PW_TMP_BUILD_DIR}
+mkdir -p ${OMPI_TMP_BUILD_DIR}
 
 echo "===> Downloading OpenMPI v$OMPI_VERSION"
 cd ${OMPI_TMP_BUILD_DIR} && wget -O openmpi-$OMPI_VERSION.tar.gz $OMPI_URL && tar -xzf openmpi-$OMPI_VERSION.tar.gz

--- a/build_install_openmpi.sh
+++ b/build_install_openmpi.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#==============================
+echo Explicit install of OpenMPI outside of Spack
+#==============================
+
+#======================================
+# ASSUME THAT THIS STEP IS ALREADY DONE
+# OR IT IS SIMPLY MISSING.
+#======================================
+# Need to install pmi.h headers
+#sudo yum install -y pmix-devel
+# To check if this package is present,
+# rpm -aq | grep pmix-devel
+
+#======================================
+# To check which versions of gcc are available
+# on Rocky8 and Rocky9, run the following:
+# ls /opt/rh/ | grep gcc
+# and the output will be a list like this:
+# gcc-toolset-<9|10|11|12|13|14>
+gcc_version=$(gcc --version | awk 'NR==1{print $3}')
+echo "===> Will build OpenMPI with gcc v$gcc_version"
+
+echo "===> Set up OpenMPI build environment variables"
+
+# OpenMPI needs to be installed in a shared directory
+export PW_SW_ROOT=${HOME}/pw/software
+export OMPI_DIR=${PW_SW_ROOT}/openmpi
+
+# Check if OpenMPI is already installed
+if [ -d $OMPI_DIR ]; then
+	echo It appears that OpenMPI is already installed at $OMPI_DIR
+	echo Exiting installer.
+        exit 0
+fi
+
+# Proceed with installation
+mkdir -p $OMPI_DIR/bin
+mkdir -p $OMPI_DIR/lib
+
+
+# Update OpenMPI version as needed
+# v5.0+ requires PMIx.
+# OpenMPI 4.1.6
+export OMPI_MAJOR_VERSION=4.1
+export OMPI_MINOR_VERSION=.6
+# OpenMPI 5.0.1 (Recommended by spack-stack)
+#export OMPI_MAJOR_VERSION=5.0
+#export OMPI_MINOR_VERSION=.1
+export OMPI_VERSION=${OMPI_MAJOR_VERSION}${OMPI_MINOR_VERSION}
+export OMPI_URL_PREFIX="https://download.open-mpi.org/release/open-mpi"
+export OMPI_URL="$OMPI_URL_PREFIX/v$OMPI_MAJOR_VERSION/openmpi-$OMPI_VERSION.tar.gz"
+export PATH=$OMPI_DIR/bin:$PATH
+export LD_LIBRARY_PATH=$OMPI_DIR/lib:$LD_LIBRARY_PATH
+export MANPATH=$OMPI_DIR/share/man:$MANPATH
+
+# For SLURM-OpenMPI integration (i.e. launch via srun).
+# Requires slurm-devel for pmi<1|2|x>.h header files.
+# If you do not have access to these, you can still use
+# mpiexec with sbatch, but you won't be able to launch
+# MPI jobs directly with srun (see examples below).
+# To disable these config options, set with_pmi=false.
+# Also set to false if using OpenMPI v5+!
+with_pmi=false
+if [ "$with_pmi" == "true" ]; then
+    echo "======> Setting OMPI_SLURM_PMI env vars..."
+    # Use this if you get pmi.h from slurm-devel
+    #export OMPI_SLURM_PMI_INCLUDE=/usr/include/slurm
+    # Use this if you get pmi.h from pmix-devel
+    export OMPI_SLURM_PMI_INCLUDE=/usr/include
+    export OMPI_SLURM_PMI_LIBDIR=/usr/lib64
+fi
+
+if [ "$with_pmi" == "false" ]; then
+    echo "======> Setting OMPI_SLURM_PMIX env vars..."
+    # Use this if you get pmix.h from slurm-devel
+    #export OMPI_SLURM_PMIX_INCLUDE=/usr/include/slurm
+    # Use this if you get pmix.h from pmix-devel
+    export OMPI_SLURM_PMIX_INCLUDE=/usr/include
+    export OMPI_SLURM_PMIX_LIBDIR=/usr/lib64
+fi
+# Not present if you use pmix-devel, above.
+# You will need this if you use slurm-devel
+# in the step_00a script. However, I had 
+# trouble getting this .rpm.
+#export C_INCLUDE_PATH=/usr/include/slurm
+
+echo "===> Making temporary build dir"
+# Do not delete existing temporary OMPI dir to speed
+# up development testing of downstream Spack actions
+export OMPI_TMP_BUILD_DIR=${PW_SW_ROOT}/tmp/ompi
+#rm -rf $OMPI_TMP_BUILD_DIR
+mkdir -p ${PW_TMP_BUILD_DIR}
+
+echo "===> Downloading OpenMPI v$OMPI_VERSION"
+cd ${OMPI_TMP_BUILD_DIR} && wget -O openmpi-$OMPI_VERSION.tar.gz $OMPI_URL && tar -xzf openmpi-$OMPI_VERSION.tar.gz
+
+echo "===> Configure OMPI"
+# Allow for up to 30 concurrent compile jobs with -j
+cd ${OMPI_TMP_BUILD_DIR}/openmpi-$OMPI_VERSION
+
+if [ "$with_pmi" == "true" ]; then
+    echo "======> with PMI"
+    ./configure --prefix=$OMPI_DIR --with-flux-pmi --with-pmi=$OMPI_SLURM_PMI_INCLUDE --with-pmi-libdir=$OMPI_SLURM_PMI_LIBDIR
+fi
+
+if [ "$with_pmi" == "false" ]; then
+    echo "======> without PMI but with PMIX"
+    # Fails b/c cannot build external PMIX and internal HWloc or libevent
+    #./configure --with-pmix=${OMPI_SLURM_PMIX_INCLUDE} --with-pmix-libdir=${OMPI_SLURM_PMIX_LIBDIR} --prefix=$OMPI_DIR
+
+    # Try internal PMIX and install internal PMIX headers, too.
+    ./configure --with-pmix --with-pmix-headers --prefix=$OMPI_DIR
+fi
+
+echo "===> Compile and install OMPI"
+make install -j 30
+
+echo "===> Create env loading script..."
+echo "export OMPI_DIR=${OMPI_DIR}" > ${OMPI_DIR}/env.sh
+echo "export PATH=${OMPI_DIR}/bin:\$PATH" >> ${OMPI_DIR}/env.sh
+echo "export LD_LIBRARY_PATH=\$OMPI_DIR/lib:\$LD_LIBRARY_PATH" >> ${OMPI_DIR}/env.sh
+echo "export MANPATH=\$OMPI_DIR/share/man:\$MANPATH" >> ${OMPI_DIR}/env.sh
+
+echo "Now that OpenMPI is installed, test it with the following steps:"
+echo " "
+echo "# Source the environment"
+echo "source ${OMPI_DIR}/env.sh "
+echo " "
+echo "# Compile test code"
+echo "mpicc -o mpitest.out mpitest.c"
+echo " "
+echo "# Run test with PMI. You may not need the --mpi=pmi2 flag."
+echo "srun -N 2 -n 4 --mpi=pmi2 mpitest.out"
+echo " "
+echo "# Run test without PMI. mpiexec/mpirun are invoked within sbatch scripts!"
+echo "# Note that here, the mpiexec -N option specifies the number of tasks per"
+echo "# node, not the total number of tasks, which is what is in srun -n."
+echo "sbatch --output=tmp.std.out --exclusive --nodes=2 --wrap \"${OMPI_DIR}/bin/mpiexec -N 2 a.out\""

--- a/build_install_openmpi.sh
+++ b/build_install_openmpi.sh
@@ -48,7 +48,7 @@ echo "===> Will build OpenMPI with gcc v$gcc_version"
 #export OMPI_MINOR_VERSION=.6
 # OpenMPI 5.0.1 (Recommended by spack-stack)
 export OMPI_MAJOR_VERSION=5.0
-export OMPI_MINOR_VERSION=.1
+export OMPI_MINOR_VERSION=.8
 export OMPI_VERSION=${OMPI_MAJOR_VERSION}${OMPI_MINOR_VERSION}
 export OMPI_URL_PREFIX="https://download.open-mpi.org/release/open-mpi"
 export OMPI_URL="$OMPI_URL_PREFIX/v$OMPI_MAJOR_VERSION/openmpi-$OMPI_VERSION.tar.gz"

--- a/build_install_openmpi.sh
+++ b/build_install_openmpi.sh
@@ -5,19 +5,36 @@ echo Explicit install of OpenMPI outside of Spack
 
 #======================================
 # ASSUME THAT THIS STEP IS ALREADY DONE
-# OR IT IS SIMPLY MISSING.
+# OR IT IS SIMPLY MISSING. For now, I
+# have hard coded with_pmi=false
 #======================================
-# Need to install pmi.h headers
+# Need to install pmi.h headers to use
+# PMI. The best place to get them is 
+# pmix-devel (see below). Another option 
+# is slurm-devel, but the default 
+# version of that package conflicts with 
+# the newer, preinstalled Slurm versions.
+#
 #sudo yum install -y pmix-devel
+#
 # To check if this package is present,
 # rpm -aq | grep pmix-devel
 
-#======================================
+#===========================================
 # To check which versions of gcc are available
 # on Rocky8 and Rocky9, run the following:
 # ls /opt/rh/ | grep gcc
 # and the output will be a list like this:
 # gcc-toolset-<9|10|11|12|13|14>
+#
+# Currently, just use whatever is the default
+# gcc. Users could customize which gcc with inputs
+# to this workflow and/or running
+#
+# source /opt/rh/gcc-toolset-<gcc_version>/enable
+#
+# in this script and/or in their .bashrc.
+#=================================================
 gcc_version=$(gcc --version | awk 'NR==1{print $3}')
 echo "===> Will build OpenMPI with gcc v$gcc_version"
 
@@ -37,7 +54,6 @@ fi
 # Proceed with installation
 mkdir -p $OMPI_DIR/bin
 mkdir -p $OMPI_DIR/lib
-
 
 # Update OpenMPI version as needed
 # v5.0+ requires PMIx.
@@ -88,7 +104,7 @@ fi
 echo "===> Making temporary build dir"
 # Do not delete existing temporary OMPI dir to speed
 # up development testing of downstream Spack actions
-export OMPI_TMP_BUILD_DIR=${PW_SW_ROOT}/tmp/ompi
+export OMPI_TMP_BUILD_DIR=${PW_SW_ROOT}/tmp/openmpi
 #rm -rf $OMPI_TMP_BUILD_DIR
 mkdir -p ${PW_TMP_BUILD_DIR}
 

--- a/build_install_openmpi.sh
+++ b/build_install_openmpi.sh
@@ -38,11 +38,28 @@ echo Explicit install of OpenMPI outside of Spack
 gcc_version=$(gcc --version | awk 'NR==1{print $3}')
 echo "===> Will build OpenMPI with gcc v$gcc_version"
 
+#======================================
+# Specify version of OpenMPI to build
+#======================================
+# Update OpenMPI version as needed
+# v5.0+ requires PMIx.
+# OpenMPI 4.1.6
+#export OMPI_MAJOR_VERSION=4.1
+#export OMPI_MINOR_VERSION=.6
+# OpenMPI 5.0.1 (Recommended by spack-stack)
+export OMPI_MAJOR_VERSION=5.0
+export OMPI_MINOR_VERSION=.1
+export OMPI_VERSION=${OMPI_MAJOR_VERSION}${OMPI_MINOR_VERSION}
+export OMPI_URL_PREFIX="https://download.open-mpi.org/release/open-mpi"
+export OMPI_URL="$OMPI_URL_PREFIX/v$OMPI_MAJOR_VERSION/openmpi-$OMPI_VERSION.tar.gz"
+
+#=====================================================
 echo "===> Set up OpenMPI build environment variables"
+#=====================================================
 
 # OpenMPI needs to be installed in a shared directory
 export PW_SW_ROOT=${HOME}/pw/software
-export OMPI_DIR=${PW_SW_ROOT}/openmpi
+export OMPI_DIR=${PW_SW_ROOT}/openmpi-${OMPI_VERSION}
 
 # Check if OpenMPI is already installed
 if [ -d $OMPI_DIR ]; then
@@ -55,17 +72,6 @@ fi
 mkdir -p $OMPI_DIR/bin
 mkdir -p $OMPI_DIR/lib
 
-# Update OpenMPI version as needed
-# v5.0+ requires PMIx.
-# OpenMPI 4.1.6
-export OMPI_MAJOR_VERSION=4.1
-export OMPI_MINOR_VERSION=.6
-# OpenMPI 5.0.1 (Recommended by spack-stack)
-#export OMPI_MAJOR_VERSION=5.0
-#export OMPI_MINOR_VERSION=.1
-export OMPI_VERSION=${OMPI_MAJOR_VERSION}${OMPI_MINOR_VERSION}
-export OMPI_URL_PREFIX="https://download.open-mpi.org/release/open-mpi"
-export OMPI_URL="$OMPI_URL_PREFIX/v$OMPI_MAJOR_VERSION/openmpi-$OMPI_VERSION.tar.gz"
 export PATH=$OMPI_DIR/bin:$PATH
 export LD_LIBRARY_PATH=$OMPI_DIR/lib:$LD_LIBRARY_PATH
 export MANPATH=$OMPI_DIR/share/man:$MANPATH

--- a/stop_workers.sh
+++ b/stop_workers.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Specify list of nodes to shut down on command line, e.g.:
+# ./stop_workers.sh sfgary-azure2-00017-1-[0001-0011]
+
+echo "Stopping workers: ${1}"
+
+sudo scontrol update nodename="${1}" state=power_down_force
+
+echo "Workers should be stopped. Check their status in sinfo."
+

--- a/workflow/build_install_openmpi.yaml
+++ b/workflow/build_install_openmpi.yaml
@@ -1,1 +1,39 @@
 # Workflow to build and install OpenMPI
+# using ../build_install_openmpi.sh
+jobs:
+  main:
+    ssh:
+      remoteHost: ${{inputs.resource.ip}}
+    steps:
+      - name: Get code
+        run: |
+          echo "Cloning repo to $PWD"
+          git clone https://github.com/${{ inputs.gh_org}}/${{ inputs.gh_repo}}
+          echo "Checking out branch ${{ inputs.gh_branch}}"
+          cd ${{ inputs.gh_repo }}
+          git checkout ${{ inputs.gh_branch }}
+      - name: Run OpenMPI build and install
+        run: |
+          cd ${{ inputs.gh_repo }}
+          ./build_install_openmpi.sh
+'on':
+  execute:
+    inputs:
+      resource:
+        label: Resource Target
+        type: compute-clusters
+        autoselect: true
+        optional: false
+      gh_org:
+        label: GitHub organization/owner
+        type: string
+        default: parallelworks
+      gh_repo:
+        label: GitHub repository
+        type: string
+        default: workflow-utils
+      gh_branch:
+        label: GitHub branch
+        type: string
+        default: main
+

--- a/workflow/build_install_openmpi.yaml
+++ b/workflow/build_install_openmpi.yaml
@@ -1,0 +1,1 @@
+# Workflow to build and install OpenMPI


### PR DESCRIPTION
Adds `build_install_openmpi.sh` and `./workflow/build_install_openmpi.yaml` to the repository as a way to install OpenMPI to support other workflows.